### PR TITLE
Add requests session support

### DIFF
--- a/dnsdumpster/DNSDumpsterAPI.py
+++ b/dnsdumpster/DNSDumpsterAPI.py
@@ -21,6 +21,8 @@ class DNSDumpsterAPI(object):
         self.verbose = verbose
         if not session:
             self.session = requests.Session()
+        else:
+            self.session = session
 
     def display_message(self, s):
         if self.verbose:


### PR DESCRIPTION
Added an option to provide a requests Session object to use for the requests.
This is useful since you can pass options through the session object, such as verify_ssl, and proxy options.

I replaced all calls that used the previous temporary session with the passed session. 
Passing a session also helps optimize connections, as it can use connection pooling.