### PR TITLE
Avoid raising false alarms regarding query errors

### DIFF
--- a/dnsdumpster/DNSDumpsterAPI.py
+++ b/dnsdumpster/DNSDumpsterAPI.py
@@ -85,7 +85,7 @@ class DNSDumpsterAPI(object):
             )
             return []
 
-        if 'error' in req.content.decode('utf-8'):
+        if 'There was an error getting results' in req.content.decode('utf-8'):
             print("There was an error getting results", file=sys.stderr)
             return []
 


### PR DESCRIPTION
The word 'error' can show up in the output without there being an actual error.