### PR TITLE
decode('base64') change on saving xls

### DIFF
--- a/dnsdumpster/API_example.py
+++ b/dnsdumpster/API_example.py
@@ -38,4 +38,4 @@ print(repr(base64.b64decode(res['image_data'])[:20]) + '...') # to save it somew
 xls_retrieved = res['xls_data'] is not None
 print("\n\n\nRetrieved XLS hosts? {} (accessible in 'xls_data')".format(xls_retrieved))
 print(repr(base64.b64decode(res['xls_data'])[:20]) + '...') # to save it somewhere else.
-# open('tsebo.com.xlsx','wb').write(res['xls_data'].decode('base64')) # example of saving xlsx
+# open('tsebo.com.xlsx','wb').write(base64.b64decode(res['xls_data'])) # example of saving xlsx


### PR DESCRIPTION
We can use this form -> open('tsebo.com.xlsx','wb').write(base64.b64decode(res['xls_data'])) 

Because when I tried to run , I got an error, now i use this form it runs good, and it's better because we got "import base64" on the code