### PR TITLE
Update DNSDumpsterAPI.py

### DIFF
--- a/dnsdumpster/DNSDumpsterAPI.py
+++ b/dnsdumpster/DNSDumpsterAPI.py
@@ -74,7 +74,7 @@ class DNSDumpsterAPI(object):
 
         cookies = {'csrftoken': csrf_middleware}
         headers = {'Referer': dnsdumpster_url}
-        data = {'csrfmiddlewaretoken': csrf_middleware, 'targetip': domain}
+        data = {'csrfmiddlewaretoken': csrf_middleware, 'targetip': domain, 'user': 'free'}
         req = self.session.post(dnsdumpster_url, cookies=cookies, data=data, headers=headers)
 
         if req.status_code != 200:


### PR DESCRIPTION
DNSDumpster now requires the 'user' parameter in the POST request, so I added the free user to the request.