### PR TITLE
Update API

### DIFF
--- a/dnsdumpster/DNSDumpsterAPI.py
+++ b/dnsdumpster/DNSDumpsterAPI.py
@@ -73,8 +73,8 @@ class DNSDumpsterAPI(object):
         self.display_message('Retrieved token: %s' % csrf_middleware)
 
         cookies = {'csrftoken': csrf_middleware}
-        headers = {'Referer': dnsdumpster_url}
-        data = {'csrfmiddlewaretoken': csrf_middleware, 'targetip': domain}
+        headers = {'Referer': dnsdumpster_url, 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36'}
+        data = {'csrfmiddlewaretoken': csrf_middleware, 'targetip': domain, 'user': 'free'}
         req = self.session.post(dnsdumpster_url, cookies=cookies, data=data, headers=headers)
 
         if req.status_code != 200:


### PR DESCRIPTION
DNSdumpster API is failed to produce the result. Therefore, to make the dnsdumpster API workable again, add user agent to header and 'user':'free' to data